### PR TITLE
Feature/UIG-2133 pill checkable disable fix test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/web-components/apps/playground/src/app/pill/pill.element.ts
+++ b/web-components/apps/playground/src/app/pill/pill.element.ts
@@ -12,6 +12,18 @@ export class PillElement extends HTMLElement {
                         <vl-pill>Option 1</vl-pill>
                     </div>
                     <div class="container">
+                        <h3 is="vl-h3" data-vl-has-border>Pill success</h3>
+                        <vl-pill data-vl-type="success">Option 1</vl-pill>
+                    </div>
+                    <div class="container">
+                        <h3 is="vl-h3" data-vl-has-border>Pill warning</h3>
+                        <vl-pill data-vl-type="warning">Option 1</vl-pill>
+                    </div>
+                    <div class="container">
+                        <h3 is="vl-h3" data-vl-has-border>Pill error</h3>
+                        <vl-pill data-vl-type="error">Option 1</vl-pill>
+                    </div>
+                    <div class="container">
                         <h3 is="vl-h3" data-vl-has-border>Pill checkable</h3>
                         <vl-pill data-vl-checkable>Option 1</vl-pill>
                     </div>

--- a/web-components/apps/playground/src/app/pill/pill.element.ts
+++ b/web-components/apps/playground/src/app/pill/pill.element.ts
@@ -23,6 +23,14 @@ export class PillElement extends HTMLElement {
                         <h3 is="vl-h3" data-vl-has-border>Pill disabled</h3>
                         <vl-pill data-vl-disabled>Option 1</vl-pill>
                     </div>
+                    <div class="container">
+                        <h3 is="vl-h3" data-vl-has-border>Pill checkable and disabled</h3>
+                        <vl-pill data-vl-checkable data-vl-disabled>Option 2</vl-pill>
+                    </div>
+                    <div class="container">
+                        <h3 is="vl-h3" data-vl-has-border>Pill checkable, checked and disabled</h3>
+                        <vl-pill data-vl-checkable data-vl-disabled data-vl-checked>Option 2</vl-pill>
+                    </div>
                 </div>
             </div>
       `;

--- a/web-components/apps/storybook-e2e/src/e2e/components/pill/vl-pill.stories.cy.ts
+++ b/web-components/apps/storybook-e2e/src/e2e/components/pill/vl-pill.stories.cy.ts
@@ -36,7 +36,7 @@ describe('story vl-pill', () => {
             .should('have.class', 'vl-pill__close');
     });
 
-    it('should contain a checkable pill', () => {
+    it('should contain a checkable pill that by default is unchecked but when clicked, becomes checked', () => {
         cy.visit(`${pillUrl}&args=checkable:true`);
         cy.getDataCy('pill')
             .shadow()
@@ -48,5 +48,35 @@ describe('story vl-pill', () => {
         cy.getDataCy('pill').shadow().find('.vl-pill').click({ force: true });
 
         cy.getDataCy('pill').shadow().find('input.vl-pill--checkable__checkbox').should('have.attr', 'checked');
+    });
+
+    it('should contain a checkable pill that is disabled and when clicking, does not enable the checkbox', () => {
+        cy.visit(`${pillUrl}&args=checkable:true;disabled:true`);
+        cy.getDataCy('pill')
+            .shadow()
+            .find('.vl-pill')
+            .should('have.class', 'vl-pill--checkable')
+            .find('input.vl-pill--checkable__checkbox')
+            .should(($input) => {
+                expect($input).to.have.attr('disabled')
+                expect($input).to.not.have.attr('checked')
+            })
+
+        cy.getDataCy('pill').shadow().find('.vl-pill').click({ force: true });
+
+        cy.getDataCy('pill').shadow().find('input.vl-pill--checkable__checkbox').should('not.have.attr', 'checked');
+    });
+
+    it('should contain a checkable pill that is disabled and checked, as it is checked, should show a checkmark', () => {
+        cy.visit(`${pillUrl}&args=checkable:true;disabled:true;checked:true`);
+        cy.getDataCy('pill')
+            .shadow()
+            .find('.vl-pill')
+            .should('have.class', 'vl-pill--checkable')
+            .find('input.vl-pill--checkable__checkbox')
+            .should(($input) => {
+                expect($input).to.have.attr('disabled')
+                expect($input).to.have.attr('checked')
+            });
     });
 });

--- a/web-components/libs/components/src/index.ts
+++ b/web-components/libs/components/src/index.ts
@@ -39,6 +39,7 @@ export * from './lib/modal/vl-modal.component';
 export * from './lib/loader/vl-loader.component';
 export * from './lib/pager/vl-pager.component';
 export * from './lib/pill/vl-pill.component';
+export * from './lib/pill/vl-pill.model';
 export * from './lib/pill/vl-button-pill.component';
 export * from './lib/proza-message/vl-proza-message.component';
 export * from './lib/progress-bar/vl-progress-bar.component';

--- a/web-components/libs/components/src/lib/pill/style/vl-pill.scss
+++ b/web-components/libs/components/src/lib/pill/style/vl-pill.scss
@@ -10,11 +10,26 @@ $vl-icon-font-location: 'https://cdn.omgeving.vlaanderen.be/domg/govflanders-fon
 // @govflanders component styles
 @import '@govflanders-v14/vl-ui-pill/src/scss/pill';
 
-.vl-pill--map {
-    background-color: rgba($vl-page-bg, 0.8);
-}
+.vl-pill {
 
-.vl-pill__close::before {
-    font-family: 'vlaanderen-icon' !important;
-    content: '\f157';
+    &--map {
+        background-color: rgba($vl-page-bg, 0.8);
+    }
+    &__close::before {
+        font-family: 'vlaanderen-icon' !important;
+        content: '\f157';
+    }
+
+    // Pill checkable modifier
+    &--checkable {
+        // TODO ideally this is changed in Digitaal Vlaanderen styling
+        // this will ensure we do show checkmark when it is disabled but checked
+        &__checkbox {
+            &:disabled:checked + span {
+                &::before {
+                    transform: translateZ(0) translate(-50%, -50%) scale(1);
+                }
+            }
+        }
+    }
 }

--- a/web-components/libs/components/src/lib/pill/vl-pill.component.ts
+++ b/web-components/libs/components/src/lib/pill/vl-pill.component.ts
@@ -2,12 +2,7 @@ import { html, css, LitElement, unsafeCSS } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { classMap } from 'lit/directives/class-map.js';
 import styles from './style/vl-pill.scss';
-
-const TYPE = {
-    SUCCESS: 'success',
-    WARNING: 'warning',
-    ERROR: 'error',
-};
+import { TYPE } from "./vl-pill.model";
 
 export class VlPillComponent extends LitElement {
     private disabled = false;

--- a/web-components/libs/components/src/lib/pill/vl-pill.component.ts
+++ b/web-components/libs/components/src/lib/pill/vl-pill.component.ts
@@ -50,6 +50,8 @@ export class VlPillComponent extends LitElement {
             },
             checked: {
                 type: Boolean || undefined,
+                attribute: 'data-vl-checked',
+                reflect: true,
             },
         };
     }
@@ -122,6 +124,7 @@ export class VlPillComponent extends LitElement {
                         type="checkbox"
                         id="checkbox"
                         name="checkbox"
+                        ?disabled=${this.disabled}
                         ?checked=${this.checked}
                         ${ref(this.checkboxRef)}
                         value="checked"

--- a/web-components/libs/components/src/lib/pill/vl-pill.model.ts
+++ b/web-components/libs/components/src/lib/pill/vl-pill.model.ts
@@ -1,0 +1,7 @@
+export const TYPE = {
+    SUCCESS: 'success',
+    WARNING: 'warning',
+    ERROR: 'error',
+} as const;
+
+export type TYPE = typeof TYPE[keyof typeof TYPE];


### PR DESCRIPTION
- test: add a new e2E test for pill component related to disabled checkable pill
- chore: update git ignore
- fix: in pill ensure disabled also disables potential checkbox
- chore: add Pill checkable & disabled example in playground
> when pill component is disabled; the checkbox will also be disabled; however the checked state will not be correctly reflected; this is due to existing styling. This can be fixed however if it would ever be necessary